### PR TITLE
Use a slightly more correct calling convention for OpenGL/Vulkan procs

### DIFF
--- a/src/opengl.zig
+++ b/src/opengl.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 const c = @import("c.zig").c;
 const Window = @import("Window.zig");
@@ -122,13 +123,12 @@ pub inline fn extensionSupported(extension: [:0]const u8) bool {
     return c.glfwExtensionSupported(extension.ptr) == c.GLFW_TRUE;
 }
 
-const builtin = @import("builtin");
 /// Client API function pointer type.
 ///
 /// Generic function pointer used for returning client API function pointers.
 ///
 /// see also: context_glext, glfwGetProcAddress
-pub const GLProc = *const fn () callconv(.C) void;
+pub const GLProc = *const fn () callconv(if (builtin.os.tag == .windows and builtin.cpu.arch == .x86) .Stdcall else .C) void;
 
 /// Returns the address of the specified function for the current context.
 ///

--- a/src/vulkan.zig
+++ b/src/vulkan.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 const c = @import("c.zig").c;
 const Window = @import("Window.zig");
@@ -93,7 +94,7 @@ pub inline fn getRequiredInstanceExtensions() ?[][*:0]const u8 {
 /// Generic function pointer used for returning Vulkan API function pointers.
 ///
 /// see also: vulkan_proc, glfw.getInstanceProcAddress
-pub const VKProc = *const fn () callconv(.C) void;
+pub const VKProc = *const fn () callconv(if (builtin.os.tag == .windows and builtin.cpu.arch == .x86) .Stdcall else .C) void;
 
 /// Returns the address of the specified Vulkan instance function.
 ///


### PR DESCRIPTION
Annotates OpenGL and Vulkan function pointer types with a more technically correct calling convention.

I doubt the current use of `callconv(.C)` is causing any problems in the wild since out of the platforms GLFW supports this only affects 32-bit Windows, but it might be nice to correct these annotations for the sake of completeness.

OpenGL `APIENTRY` calling convention macro:

https://github.com/KhronosGroup/EGL-Registry/blob/7db3005d4c2cb439f129a0adc931f3274f9019e6/api/KHR/khrplatform.h#L122-L127

Vulkan `API_CALL` calling convention macro:

https://github.com/KhronosGroup/Vulkan-Docs/blob/d99193d3fcc4b2a0dacc0a9d7e4951ea611a3e96/include/vulkan/vk_platform.h#L39-L59

Zig's definition of `std.os.windows.WINAPI` might also be a relevant reference:

https://github.com/ziglang/zig/blob/master/lib/std/os/windows.zig#L2539-L2542

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.