### PR TITLE
Corrected docs in `glfw.Window`

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -282,7 +282,7 @@ pub const Hints = struct {
 /// hints using `glfw.Window.hint`.
 ///
 /// Successful creation does not change which context is current. Before you can use the newly
-/// created context, you need to make it current using `glfw.Window.makeContextCurrent`. For
+/// created context, you need to make it current using `glfw.makeContextCurrent`. For
 /// information about the `share` parameter, see context_sharing.
 ///
 /// The created window, framebuffer and context may differ from what you requested, as not all


### PR DESCRIPTION
In the doc comments of `glfw.Window.create`, you refer to the function `glfw.Winodw.makeContextCurrent`, which doesn't exist. What does exist, though, is `glfw.makeContextCurrent`, so I've fixed that.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.