### PR TITLE
Add default values for `Window.SizeOptional`

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -624,8 +624,8 @@ pub inline fn setSize(self: Window, size: Size) void {
 /// A size with option width/height, used to represent e.g. constraints on a windows size while
 /// allowing specific axis to be unconstrained (null) if desired.
 pub const SizeOptional = struct {
-    width: ?u32,
-    height: ?u32,
+    width: ?u32 = null,
+    height: ?u32 = null,
 };
 
 /// Sets the size limits of the specified window's content area.


### PR DESCRIPTION
This way, you don't have to tediously write out a size that you don't even care about.

Example:
```zig
window.setSizeLimits(.{ .width = 800, .height = 600 }, .{ .width = null, .height = null }); // old
window.setSizeLimits(.{ .width = 800, .height = 600 }, .{}); // new
```

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.