### PR TITLE
Fix docs for `glfw.Window.create`

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -305,7 +305,7 @@ pub const Hints = struct {
 /// glfw.Window.setMonitor. This will not affect its OpenGL or OpenGL ES context.
 ///
 /// By default, newly created windows use the placement recommended by the window system. To create
-/// the window at a specific position, make it initially invisible using the glfw.version window
+/// the window at a specific position, make it initially invisible using the `visible` window
 /// hint, set its position and then show it.
 ///
 /// As long as at least one full screen window is not iconified, the screensaver is prohibited from


### PR DESCRIPTION
1. There is no `version` window hint
2. How would a version window hint affect the visibility?

Jokes aside, I simply fixed the docs.



- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.